### PR TITLE
Return tunnel URL from CJS shim

### DIFF
--- a/cjs/index.d.ts
+++ b/cjs/index.d.ts
@@ -1,2 +1,2 @@
 import { Options } from '../options.js';
-export default function tunnelmole(options: Options): Promise<void>
+export default function tunnelmole(options: Options): Promise<string>

--- a/cjs/tunnelmole.js
+++ b/cjs/tunnelmole.js
@@ -6,7 +6,7 @@
 
 const tunnelmole = async function(options) {
     const tunnelmole = await import('../dist/src/index.js');
-    tunnelmole.tunnelmole(options);
+    return tunnelmole.tunnelmole(options);
 };
 
 module.exports = tunnelmole;


### PR DESCRIPTION
Without this return one cannot get tunnel URL when using CJS.

This snippet will log `undefined`
```js
const tunnelmole = require('tunnelmole/cjs');
tunnelmole({ port: 8888 }).then(url => console.log("tunnelmole url: ", url);)
```