### PR TITLE
remove deprecated dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tunnelmole",
-  "version": "2.2.9",
+  "version": "2.2.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tunnelmole",
-      "version": "2.2.9",
+      "version": "2.2.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "author": "Robbie Cahill",
   "license": "MIT",
   "dependencies": {
-    "@types/commander": "^2.12.2",
     "@types/deep-equal": "^1.0.1",
     "@types/is-number": "^7.0.3",
     "@types/jest": "^29.5.0",


### PR DESCRIPTION
- removes deprecated `@type/commander` dependency - this seperate type package is no longer needed as its provided by the main package (which is why its deprecated) 
- the package version was updated as well by `npm install` (looks like it was out of date)

I am using `tunnelmole-client` in a project and installing packages warned me of the deprecated sub-dependency. See: https://www.npmjs.com/package/@types/commander

`npm run build` and `npm run tests` complete without error.