### PR TITLE
Remove unused deep-equal dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,15 @@
 {
   "name": "tunnelmole",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tunnelmole",
-      "version": "2.2.13",
+      "version": "2.2.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@types/commander": "^2.12.2",
-        "@types/deep-equal": "^1.0.1",
         "@types/is-number": "^7.0.3",
         "@types/jest": "^29.5.0",
         "@types/node-fetch": "^2.5.7",
@@ -22,7 +20,6 @@
         "@types/ws": "^7.2.4",
         "axios": "^1.3.5",
         "commander": "^5.1.0",
-        "deep-equal": "^2.0.3",
         "deepmerge": "^4.2.2",
         "is-number": "^7.0.0",
         "multer": "^1.4.5-lts.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   "author": "Robbie Cahill",
   "license": "MIT",
   "dependencies": {
-    "@types/deep-equal": "^1.0.1",
     "@types/is-number": "^7.0.3",
     "@types/jest": "^29.5.0",
     "@types/node-fetch": "^2.5.7",
@@ -64,7 +63,6 @@
     "@types/ws": "^7.2.4",
     "axios": "^1.3.5",
     "commander": "^5.1.0",
-    "deep-equal": "^2.0.3",
     "deepmerge": "^4.2.2",
     "is-number": "^7.0.0",
     "multer": "^1.4.5-lts.1",


### PR DESCRIPTION
`deep-equal` is listed as a dependency, but isn't actually used, so it can be safely removed.

Removing `deep-equal` means that its 50 sub-dependencies (colored purple) will also be removed:
![Dependency graph with deep-equal highlighted](https://github.com/user-attachments/assets/6321cc4d-f84d-4de3-8dc5-6b9a3b4050e9)
